### PR TITLE
Introduce component parameters to configure how Vault uses the `X-Forwarded-For` header

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -18,14 +18,14 @@ parameters:
       enabled: true
       annotations: {}
       host: vault.todo.tld
-    storage:
-      size: 10G
-      class: ''
     x_forwarded_for:
       authorized_addrs: "127.0.0.1/32"
       hop_skips: "0"
       reject_not_authorized: "false"
       reject_not_present: "false"
+    storage:
+      size: 10G
+      class: ''
     resources:
       requests:
         memory: 256Mi

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -21,6 +21,7 @@ parameters:
     storage:
       size: 10G
       class: ''
+    x_forwarded_for_authorized_addrs: "127.0.0.1/32"
     resources:
       requests:
         memory: 256Mi
@@ -90,6 +91,7 @@ parameters:
                 tls_disable = true
                 address = "[::]:${vault:helm_values:server:service:targetPort}"
                 cluster_address = "[::]:8201"
+                x_forwarded_for_authorized_addrs = "${vault:x_forwarded_for_authorized_addrs}"
               }
               listener "tcp" {
                 tls_disable = true

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -21,7 +21,11 @@ parameters:
     storage:
       size: 10G
       class: ''
-    x_forwarded_for_authorized_addrs: "127.0.0.1/32"
+    x_forwarded_for:
+      authorized_addrs: "127.0.0.1/32"
+      hop_skips: "0"
+      reject_not_authorized: "false"
+      reject_not_present: "false"
     resources:
       requests:
         memory: 256Mi
@@ -91,7 +95,10 @@ parameters:
                 tls_disable = true
                 address = "[::]:${vault:helm_values:server:service:targetPort}"
                 cluster_address = "[::]:8201"
-                x_forwarded_for_authorized_addrs = "${vault:x_forwarded_for_authorized_addrs}"
+                x_forwarded_for_authorized_addrs = "${vault:x_forwarded_for:authorized_addrs}"
+                x_forwarded_for_hop_skips = "${vault:x_forwarded_for:hop_skips}"
+                x_forwarded_for_reject_not_authorized = "${vault:x_forwarded_for:reject_not_authorized}"
+                x_forwarded_for_reject_not_present = "${vault:x_forwarded_for:reject_not_present}"
               }
               listener "tcp" {
                 tls_disable = true

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -102,7 +102,11 @@ limits:
 
 The resource requests and limits.
 
-== `x_forwarded_for_authorized_addrs`
+== `x_forwarded_for`
+
+This section allows users to configure how Vault uses the information in the `X-Forwarded-For` header in client connections.
+
+=== `authorized_addrs`
 
 [horizontal]
 type:: string
@@ -111,9 +115,48 @@ default:: `127.0.0.1/32`
 This parameter allows users to specify the list of source IP CIDRs for which an `X-Forwarded-For` header will be trusted.
 Since Vault doesn't accept the empty string as a valid option, we set the parameter to only trust `X-Forwarded-For` headers from `127.0.0.1/32` by default.
 
+To avoid issues with parameter interpolation, multiple entries should be specified as a comma-separated list.
+
 If you want to use functionality in Vault which requires the real source IP of requests, you should set this parameter to a CIDR which includes the IPs of your ingress controller.
 
-See also the https://www.vaultproject.io/docs/configuration/listener/tcp#x_forwarded_for_authorized_addrs[Vault documentation].
+Also see the https://www.vaultproject.io/docs/configuration/listener/tcp#x_forwarded_for_authorized_addrs[Vault documentation].
+
+=== `hop_skips`
+
+[horizontal]
+type:: number
+default:: `"0"`
+
+The number of entries in the `X-Forwarded-For` header to skip.
+You may have to set this parameter, if you're deploying this component on a cluster which is behind multiple HTTP load balancers.
+
+See the https://www.vaultproject.io/docs/configuration/listener/tcp#x_forwarded_for_hop_skips[Vault documentation] for more details.
+
+== `reject_not_authorized`
+
+[horizontal]
+type:: bool
+default:: `"false"`
+
+By default, if there's an `X-Forwarded-For` header in a connection from an address which isn't in `x_forwarded_for_authorized_addrs`, the header will be ignored and the client address is used as-is.
+
+If this is set to `true`, such client connections are rejected instead.
+
+We default this parameter to `false` to provide an usable setup out of the box.
+If you expect that all valid client connections will have an `X-Forwarded-For` header, we strongly recommend setting it to `true` if you configure `x_forwarded_for_authorized_addrs`.
+
+== `reject_not_present`
+
+[horizontal]
+type:: bool
+default:: `"false"`
+
+By default, if there is no `X-Forwarded-For` header in a connection from an address which isn't in `x_forwarded_For_authorized_addrs` or if the header is empty, the client address will be used as-is.
+
+If this parameter is set to `true`, such client connections are rejected instead.
+
+We default this parameter to `false` to provide an usable setup out of the box.
+If you expect that all valid client connections will have an `X-Forwarded-For` header, we strongly recommend setting it to `true` if you configure `x_forwarded_for_authorized_addrs`.
 
 == `config`
 

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -102,6 +102,19 @@ limits:
 
 The resource requests and limits.
 
+== `x_forwarded_for_authorized_addrs`
+
+[horizontal]
+type:: string
+default:: `127.0.0.1/32`
+
+This parameter allows users to specify the list of source IP CIDRs for which an `X-Forwarded-For` header will be trusted.
+Since Vault doesn't accept the empty string as a valid option, we set the parameter to only trust `X-Forwarded-For` headers from `127.0.0.1/32` by default.
+
+If you want to use functionality in Vault which requires the real source IP of requests, you should set this parameter to a CIDR which includes the IPs of your ingress controller.
+
+See also the https://www.vaultproject.io/docs/configuration/listener/tcp#x_forwarded_for_authorized_addrs[Vault documentation].
+
 == `config`
 
 [horizontal]

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -18,7 +18,9 @@ parameters:
         cpu: 1000m
     backup:
       enabled: false
-    x_forwarded_for_authorized_addrs: "198.51.100.0/24" # TEST-NET-2
+    x_forwarded_for:
+      authorized_addrs: "198.51.100.0/24" # TEST-NET-2
+      reject_not_authorized: "true"
     config:
       policies:
         - name: backup

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -18,6 +18,7 @@ parameters:
         cpu: 1000m
     backup:
       enabled: false
+    x_forwarded_for_authorized_addrs: "198.51.100.0/24" # TEST-NET-2
     config:
       policies:
         - name: backup

--- a/tests/unit/defaults_test.go
+++ b/tests/unit/defaults_test.go
@@ -15,7 +15,29 @@ import (
 )
 
 var (
-	testPath = "../../compiled/vault/vault"
+	testPath       = "../../compiled/vault/vault"
+	extraConfigHcl = `disable_mlock = true
+ui = true
+listener "tcp" {
+  tls_disable = true
+  address = "[::]:8200"
+  cluster_address = "[::]:8201"
+  x_forwarded_for_authorized_addrs = "198.51.100.0/24"
+}
+listener "tcp" {
+  tls_disable = true
+  address = "[::]:9200"
+  telemetry {
+    unauthenticated_metrics_access = true
+  }
+}
+storage "raft" {
+  path = "/vault/data"
+}
+service_registration "kubernetes" {}
+telemetry {
+  disable_hostname = true
+}`
 )
 
 func validate(t *testing.T, path string) {
@@ -60,4 +82,16 @@ func Test_Namespace(t *testing.T) {
 	err = yaml.Unmarshal(data, &ns)
 	require.NoError(t, err)
 	assert.Equal(t, "vault", ns.Name)
+}
+
+func Test_HelmChartVaultConfig(t *testing.T) {
+	cm := corev1.ConfigMap{}
+	data, err := ioutil.ReadFile(testPath + "/10_vault/vault/templates/server-config-configmap.yaml")
+	require.NoError(t, err)
+	err = yaml.Unmarshal(data, &cm)
+	require.NoError(t, err)
+	expectedData := map[string]string{
+		"extraconfig-from-values.hcl": extraConfigHcl,
+	}
+	assert.Equal(t, expectedData, cm.Data)
 }

--- a/tests/unit/defaults_test.go
+++ b/tests/unit/defaults_test.go
@@ -23,6 +23,9 @@ listener "tcp" {
   address = "[::]:8200"
   cluster_address = "[::]:8201"
   x_forwarded_for_authorized_addrs = "198.51.100.0/24"
+  x_forwarded_for_hop_skips = "0"
+  x_forwarded_for_reject_not_authorized = "true"
+  x_forwarded_for_reject_not_present = "false"
 }
 listener "tcp" {
   tls_disable = true


### PR DESCRIPTION
Because the tcp listener config is deployed through the Helm chart, which expects the config as a string, we can't just document how to configure the options, as that would require users to copy the full config string into their tenant or cluster config.

Instead we introduce a new config section `parameters.vault.x_forwarded_for` which contains parameters to configure the following Vault tcp listener settings:

* [`x_forwarded_for_authorized_addrs`](https://www.vaultproject.io/docs/configuration/listener/tcp#x_forwarded_for_authorized_addrs)
* [`x_forwarded_for_hop_skips`](https://www.vaultproject.io/docs/configuration/listener/tcp#x_forwarded_for_hop_skips)
* [`x_forwarded_for_reject_not_authorized`](https://www.vaultproject.io/docs/configuration/listener/tcp#x_forwarded_for_reject_not_authorized)
* [`x_forwarded_for_reject_not_present`](https://www.vaultproject.io/docs/configuration/listener/tcp#x_forwarded_for_reject_not_present)

Because Vault doesn't start with `x_forwarded_for_authorized_addrs = ""`, we set the default configuration as `x_forwarded_for_authorized_addrs = "127.0.0.1/32"`, and instead disable `reject_not_authorized` and `reject_not_present` in the default config.

Fixes #8 

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
