### PR TITLE
Rename the helm chart release_name variable for Kapitan to name

### DIFF
--- a/class/vault.yml
+++ b/class/vault.yml
@@ -22,7 +22,7 @@ parameters:
         output_path: ${_instance}/10_vault
         helm_values: ${vault:helm_values}
         helm_params:
-          release_name: ${vault:name}
+          name: ${vault:name}
           namespace: ${vault:namespace}
           api_versions: networking.k8s.io/v1beta1/Ingress
           kube_version: ${vault:kubernetes_version}


### PR DESCRIPTION
Kapitan has changed the helm chart naming and release_name is
now deprecated.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

