### PR TITLE
Update dependency docker.io/vault to v1.9.4

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -7,7 +7,7 @@ parameters:
       vault:
         registry: docker.io
         repository: vault
-        version: 1.7.3
+        version: 1.9.4
       bankvaults:
         registry: docker.io
         repository: banzaicloud/bank-vaults

--- a/tests/golden/defaults/vault/vault/10_vault/vault/templates/server-statefulset.yaml
+++ b/tests/golden/defaults/vault/vault/10_vault/vault/templates/server-statefulset.yaml
@@ -80,7 +80,7 @@ spec:
               value: https://$(HOSTNAME).foobar-internal:8201
             - name: HOME
               value: /home/vault
-          image: docker.io/vault:1.7.3
+          image: docker.io/vault:1.9.4
           imagePullPolicy: IfNotPresent
           lifecycle:
             preStop:

--- a/tests/golden/defaults/vault/vault/30_backup/32_backup.yaml
+++ b/tests/golden/defaults/vault/vault/30_backup/32_backup.yaml
@@ -34,7 +34,7 @@ spec:
               value: 'true'
             - name: VAULT_ADDR
               value: http://foobar-active:8200
-          image: docker.io/vault:1.7.3
+          image: docker.io/vault:1.9.4
           imagePullPolicy: IfNotPresent
           name: backup
           ports: []


### PR DESCRIPTION
Fixes an issue where backups are broken by default on k8s 1.21+

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
