### PR TITLE
Fix race condition on first vault startup

### DIFF
--- a/class/vault.yml
+++ b/class/vault.yml
@@ -38,3 +38,9 @@ parameters:
           - vault/component/backup.jsonnet
         input_type: jsonnet
         output_path: ${_instance}/30_backup
+  commodore:
+    postprocess:
+      filters:
+        - type: jsonnet
+          path: ${_instance}/10_vault/vault/templates/
+          filter: postprocess/orderedReady.jsonnet

--- a/postprocess/orderedReady.jsonnet
+++ b/postprocess/orderedReady.jsonnet
@@ -1,0 +1,20 @@
+/**
+ * Switch to podManagementPolicy: OrderedReady
+ */
+local com = import 'lib/commodore.libjsonnet';
+local inv = com.inventory();
+local params = inv.parameters.keycloak;
+
+local sts_file = std.extVar('output_path') + '/server-statefulset.yaml';
+
+
+local sts = com.yaml_load(sts_file) + {
+  spec+: {
+    podManagementPolicy: 'OrderedReady',
+  },
+};
+
+
+{
+  'server-statefulset': sts,
+}

--- a/tests/golden/defaults/vault/vault/10_vault/vault/templates/server-statefulset.yaml
+++ b/tests/golden/defaults/vault/vault/10_vault/vault/templates/server-statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
   name: foobar
   namespace: vault
 spec:
-  podManagementPolicy: Parallel
+  podManagementPolicy: OrderedReady
   replicas: 3
   selector:
     matchLabels:
@@ -27,130 +27,130 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app.kubernetes.io/instance: foobar
-                  app.kubernetes.io/name: vault
-                  component: server
-              topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/instance: foobar
+                app.kubernetes.io/name: vault
+                component: server
+            topologyKey: kubernetes.io/hostname
       containers:
-        - args:
-            - "cp /vault/config/extraconfig-from-values.hcl /tmp/storageconfig.hcl;\n\
-              [ -n \"${HOST_IP}\" ] && sed -Ei \"s|HOST_IP|${HOST_IP?}|g\" /tmp/storageconfig.hcl;\n\
-              [ -n \"${POD_IP}\" ] && sed -Ei \"s|POD_IP|${POD_IP?}|g\" /tmp/storageconfig.hcl;\n\
-              [ -n \"${HOSTNAME}\" ] && sed -Ei \"s|HOSTNAME|${HOSTNAME?}|g\" /tmp/storageconfig.hcl;\n\
-              [ -n \"${API_ADDR}\" ] && sed -Ei \"s|API_ADDR|${API_ADDR?}|g\" /tmp/storageconfig.hcl;\n\
-              [ -n \"${TRANSIT_ADDR}\" ] && sed -Ei \"s|TRANSIT_ADDR|${TRANSIT_ADDR?}|g\"\
-              \ /tmp/storageconfig.hcl;\n[ -n \"${RAFT_ADDR}\" ] && sed -Ei \"s|RAFT_ADDR|${RAFT_ADDR?}|g\"\
-              \ /tmp/storageconfig.hcl;\n/usr/local/bin/docker-entrypoint.sh vault\
-              \ server -config=/tmp/storageconfig.hcl \n"
-          command:
-            - /bin/sh
-            - -ec
-          env:
-            - name: HOST_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.hostIP
-            - name: POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            - name: VAULT_K8S_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: VAULT_K8S_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            - name: VAULT_ADDR
-              value: http://127.0.0.1:8200
-            - name: VAULT_API_ADDR
-              value: https://vault.todo.tld
-            - name: SKIP_CHOWN
-              value: 'true'
-            - name: SKIP_SETCAP
-              value: 'true'
-            - name: HOSTNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-            - name: VAULT_CLUSTER_ADDR
-              value: https://$(HOSTNAME).foobar-internal:8201
-            - name: HOME
-              value: /home/vault
-          image: docker.io/vault:1.9.4
-          imagePullPolicy: IfNotPresent
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                  - /bin/sh
-                  - -c
-                  - sleep 5 && kill -SIGTERM $(pidof vault)
-          name: vault
-          ports:
-            - containerPort: 8200
-              name: http
-            - containerPort: 8201
-              name: https-internal
-            - containerPort: 8202
-              name: http-rep
-          readinessProbe:
+      - args:
+        - "cp /vault/config/extraconfig-from-values.hcl /tmp/storageconfig.hcl;\n\
+          [ -n \"${HOST_IP}\" ] && sed -Ei \"s|HOST_IP|${HOST_IP?}|g\" /tmp/storageconfig.hcl;\n\
+          [ -n \"${POD_IP}\" ] && sed -Ei \"s|POD_IP|${POD_IP?}|g\" /tmp/storageconfig.hcl;\n\
+          [ -n \"${HOSTNAME}\" ] && sed -Ei \"s|HOSTNAME|${HOSTNAME?}|g\" /tmp/storageconfig.hcl;\n\
+          [ -n \"${API_ADDR}\" ] && sed -Ei \"s|API_ADDR|${API_ADDR?}|g\" /tmp/storageconfig.hcl;\n\
+          [ -n \"${TRANSIT_ADDR}\" ] && sed -Ei \"s|TRANSIT_ADDR|${TRANSIT_ADDR?}|g\"\
+          \ /tmp/storageconfig.hcl;\n[ -n \"${RAFT_ADDR}\" ] && sed -Ei \"s|RAFT_ADDR|${RAFT_ADDR?}|g\"\
+          \ /tmp/storageconfig.hcl;\n/usr/local/bin/docker-entrypoint.sh vault server\
+          \ -config=/tmp/storageconfig.hcl \n"
+        command:
+        - /bin/sh
+        - -ec
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: VAULT_K8S_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: VAULT_K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: VAULT_ADDR
+          value: http://127.0.0.1:8200
+        - name: VAULT_API_ADDR
+          value: https://vault.todo.tld
+        - name: SKIP_CHOWN
+          value: 'true'
+        - name: SKIP_SETCAP
+          value: 'true'
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: VAULT_CLUSTER_ADDR
+          value: https://$(HOSTNAME).foobar-internal:8201
+        - name: HOME
+          value: /home/vault
+        image: docker.io/vault:1.9.4
+        imagePullPolicy: IfNotPresent
+        lifecycle:
+          preStop:
             exec:
               command:
-                - /bin/sh
-                - -ec
-                - vault status -tls-skip-verify
-            failureThreshold: 2
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 3
-          resources:
-            limits:
-              cpu: 1000m
-              memory: 9001Mi
-            requests:
-              cpu: 420m
-              memory: 1337Mi
-          securityContext:
-            allowPrivilegeEscalation: false
-          volumeMounts:
-            - mountPath: /vault/data
-              name: data
-            - mountPath: /vault/config
-              name: config
-            - mountPath: /home/vault
-              name: home
-        - args:
-            - --secret-shares=1
-            - --secret-threshold=1
-            - --mode=k8s
-            - --k8s-secret-namespace=vault
-            - --k8s-secret-name=foobar-seal
-            - --raft
-            - --raft-leader-address
-            - http://foobar-active:8200
-          command:
-            - bank-vaults
-            - unseal
-            - --init
-          env:
-            - name: VAULT_ADDR
-              value: http://127.0.0.1:8200
-          image: docker.io/banzaicloud/bank-vaults:1.15.2
-          name: vault-unsealer
-          ports:
-            - containerPort: 9200
-              name: vault-metrics
-            - containerPort: 9091
-              name: unseal-metrics
-          resources:
-            limits:
-              cpu: 100m
-              memory: 64Mi
+              - /bin/sh
+              - -c
+              - sleep 5 && kill -SIGTERM $(pidof vault)
+        name: vault
+        ports:
+        - containerPort: 8200
+          name: http
+        - containerPort: 8201
+          name: https-internal
+        - containerPort: 8202
+          name: http-rep
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -ec
+            - vault status -tls-skip-verify
+          failureThreshold: 2
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 3
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 9001Mi
+          requests:
+            cpu: 420m
+            memory: 1337Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /vault/data
+          name: data
+        - mountPath: /vault/config
+          name: config
+        - mountPath: /home/vault
+          name: home
+      - args:
+        - --secret-shares=1
+        - --secret-threshold=1
+        - --mode=k8s
+        - --k8s-secret-namespace=vault
+        - --k8s-secret-name=foobar-seal
+        - --raft
+        - --raft-leader-address
+        - http://foobar-active:8200
+        command:
+        - bank-vaults
+        - unseal
+        - --init
+        env:
+        - name: VAULT_ADDR
+          value: http://127.0.0.1:8200
+        image: docker.io/banzaicloud/bank-vaults:1.15.2
+        name: vault-unsealer
+        ports:
+        - containerPort: 9200
+          name: vault-metrics
+        - containerPort: 9091
+          name: unseal-metrics
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
       securityContext:
         fsGroup: 1000
         runAsGroup: 1000
@@ -159,19 +159,19 @@ spec:
       serviceAccountName: foobar
       terminationGracePeriodSeconds: 10
       volumes:
-        - configMap:
-            name: foobar-config
-          name: config
-        - emptyDir: {}
-          name: home
+      - configMap:
+          name: foobar-config
+        name: config
+      - emptyDir: {}
+        name: home
   updateStrategy:
     type: OnDelete
   volumeClaimTemplates:
-    - metadata:
-        name: data
-      spec:
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1337G
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1337G


### PR DESCRIPTION
Switch to `podManagementPolicy: OrderedReady` for statefulset. This solves the issue if two or more vault pods start at the same time and both try to bootstrap the cluster.

By using `OrderedReady` there will always be a single bootstrap node

We need to use postprocessing as the helm chart hard codes `podManagementPolicy: Parallel` 
https://github.com/hashicorp/vault-helm/blob/main/templates/server-statefulset.yaml#L18

Fixes #5 



## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
