### PR TITLE
Make podManagementPolicy configurable to allow old component behaviour

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -28,6 +28,8 @@ parameters:
     storage:
       size: 10G
       class: ''
+    # Only change to maintain backwards compatibility
+    podManagementPolicy: OrderedReady
     resources:
       requests:
         memory: 256Mi

--- a/class/vault.yml
+++ b/class/vault.yml
@@ -43,4 +43,4 @@ parameters:
       filters:
         - type: jsonnet
           path: ${_instance}/10_vault/vault/templates/
-          filter: postprocess/orderedReady.jsonnet
+          filter: postprocess/patch_podManagementPolicy.jsonnet

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -110,6 +110,17 @@ limits:
 
 The resource requests and limits.
 
+== `podManagementPolicy`
+
+[horizontal]
+type:: string
+default:: `OrderedReady`
+
+The `podManagementPolicy` for the vault statefulset
+
+WARNING: Setting this to `Parallel` might cause a race condition during initial setup.
+This parameter can't be changed after the initial deployment of the component.
+
 == `x_forwarded_for`
 
 This section allows users to configure how Vault uses the information in the `X-Forwarded-For` header in client connections.

--- a/postprocess/patch_podManagementPolicy.jsonnet
+++ b/postprocess/patch_podManagementPolicy.jsonnet
@@ -3,18 +3,18 @@
  */
 local com = import 'lib/commodore.libjsonnet';
 local inv = com.inventory();
-local params = inv.parameters.keycloak;
+local params = inv.parameters.vault;
 
 local sts_file = std.extVar('output_path') + '/server-statefulset.yaml';
 
 
 local sts = com.yaml_load(sts_file) + {
   spec+: {
-    podManagementPolicy: 'OrderedReady',
+    podManagementPolicy: params.podManagementPolicy,
   },
 };
 
 
 {
-  'server-statefulset': sts,
+  [if params.podManagementPolicy != 'Parallel' then 'server-statefulset']: sts,
 }


### PR DESCRIPTION
We switched to `OrderedReady` podManagementPolicy to prevenet a race condition during bootstrapping.

However changing podMnanagmentPolicy for an existing sts is not supported. As the race condition doesn't exist after initial boostrapping, we just make the old behaviour configurable.

Caused by #49 




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
