### PR TITLE
Disable K8up PVC backup for Vault PVCs

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -123,6 +123,8 @@ parameters:
           enabled: true
           size: ${vault:storage:size}
           storageClass: ${vault:storage:class}
+          annotations:
+            k8up.io/backup: 'false'
         ingress:
           enabled: ${vault:ingress:enabled}
           annotations: ${vault:ingress:annotations}

--- a/tests/golden/defaults/vault/vault/10_vault/vault/templates/server-statefulset.yaml
+++ b/tests/golden/defaults/vault/vault/10_vault/vault/templates/server-statefulset.yaml
@@ -168,6 +168,8 @@ spec:
     type: OnDelete
   volumeClaimTemplates:
     - metadata:
+        annotations:
+          k8up.io/backup: 'false'
         name: data
       spec:
         accessModes:


### PR DESCRIPTION
With K8up v2.6.0, K8up now backs up RWO PVCs by default. We explicitly disable PVC backup for the Vault PVCs since we're doing an application-aware backup (cf. `component/backup.jsonnet`).




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
