### PR TITLE
Refactor Vault config handling to support overwriting in hierarchy

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -42,22 +42,23 @@ parameters:
         memory: 512Mi
         cpu: 1000m
     config:
-      policies:
-        - name: backup
+      policies_:
+        backup:
           rules: |
             path "sys/storage/raft/snapshot" {
               capabilities = ["read"]
             }
-      secrets:
-        - type: kv
-          path: clusters/kv
+      secrets_:
+        clusters/kv:
+          type: kv
           description: General secrets for clusters
           options:
             version: 2
-      auth:
-        - type: kubernetes
+      auth_:
+        kubernetes:
+          type: kubernetes
           roles:
-            - name: backup
+            backup:
               bound_service_account_names: '${vault:name}-backup'
               bound_service_account_namespaces: ${vault:namespace}
               policies: backup

--- a/component/config.jsonnet
+++ b/component/config.jsonnet
@@ -4,7 +4,58 @@ local kube = import 'lib/kube.libjsonnet';
 local inv = kap.inventory();
 local params = inv.parameters.vault;
 
-local config = params.config;
+local config =
+  // This function transforms field `roles` of the passed object from an
+  // object with role names as keys and role configs as values into a list.
+  local renderRoles(data) =
+    if std.objectHas(data, 'roles') then
+      data {
+        roles: [
+          data.roles[n] {
+            name: n,
+          }
+          for n in std.objectFields(data.roles)
+          if data.roles[n] != null
+        ],
+      }
+    else
+      data;
+
+  // This function renders bankvaults config list from an object which has
+  // field `[idkey]` of each entry as keys and the remaining config as values.
+  // The function looks up the source object by reading `<sourcekey>_` in
+  // component parameter `config`.
+  //
+  // This function calls `renderRoles()` to recursively transform field
+  // `roles` of each entry of the field (if the entry has field `roles`).
+  local renderField(sourcekey, idkey) =
+    local data = std.get(params.config, '%s_' % sourcekey, {});
+    [
+      renderRoles(data[k]) {
+        [idkey]: k,
+      }
+      for k in std.objectFields(data)
+      if data[k] != null
+    ];
+
+  local rendered = std.prune({
+    // NOTE(sg): new Bankvaults fields which are expected to be lists need to
+    // be added here
+    audit: renderField('audit', 'type'),
+    auth: renderField('auth', 'path'),
+    plugins: renderField('plugins', 'plugin_name'),
+    policies: renderField('policies', 'name'),
+    secrets: renderField('secrets', 'path'),
+    startupSecrets: renderField('startupSecrets', 'path'),
+  });
+  // append configs provided in un-suffixed fields. This should preserve order
+  // of configs for existing clusters.
+  rendered {
+    [if !std.endsWith(k, '_') then k]+: params.config[k]
+    for k in std.objectFields(params.config)
+  };
+
+
 local configSecret = kube.Secret(params.name) {
   metadata+: {
     namespace: params.namespace,

--- a/tests/golden/defaults/vault/vault/22_config.yaml
+++ b/tests/golden/defaults/vault/vault/22_config.yaml
@@ -10,7 +10,8 @@ metadata:
 stringData:
   vault-config.yml: |-
     "auth":
-    - "roles":
+    - "path": "kubernetes"
+      "roles":
       - "bound_service_account_names": "foobar-backup"
         "bound_service_account_namespaces": "vault"
         "name": "backup"

--- a/tests/golden/openshift/vault/vault/22_config.yaml
+++ b/tests/golden/openshift/vault/vault/22_config.yaml
@@ -10,7 +10,8 @@ metadata:
 stringData:
   vault-config.yml: |-
     "auth":
-    - "roles":
+    - "path": "kubernetes"
+      "roles":
       - "bound_service_account_names": "foobar-backup"
         "bound_service_account_namespaces": "vault"
         "name": "backup"


### PR DESCRIPTION
We introduce new fields suffixed by a `_` which are merged with the still supported plain config fields.

We introduce new fields suffixed by a `_` which are merged with the still supported plain config fields.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
